### PR TITLE
937 track conflicts in db info

### DIFF
--- a/apps/couch/src/couch_view.erl
+++ b/apps/couch/src/couch_view.erl
@@ -118,8 +118,10 @@ list_index_files(Db) ->
 
 
 get_row_count(#view{btree=Bt}) ->
-    {ok, {Count, _, _}} = couch_btree:full_reduce(Bt),
-    {ok, Count}.
+    case couch_btree:full_reduce(Bt) of
+    {ok, {NC, _, _, _}} -> NC;
+    {ok, {OC, _, _}} -> OC
+    end.
 
 get_temp_reduce_view(Db, Language, DesignOptions, MapSrc, RedSrc) ->
     {ok, #group{views=[View]}=Group} =

--- a/apps/couch/src/couch_view_group.erl
+++ b/apps/couch/src/couch_view_group.erl
@@ -530,8 +530,12 @@ get_group_info(State) ->
 
 compute_data_size(ViewList) ->
     lists:foldl(fun(#view{btree=Btree}, Acc) ->
-        {ok, {_, _, Size}} = couch_btree:full_reduce(Btree),
-        Size + Acc
+        case couch_btree:full_reduce(Btree) of
+        {ok, {_, _, _, NSize}} ->
+            NSize + Acc;
+        {ok, {_, _, OSize}} ->
+            OSize + Acc
+        end
     end, 0, ViewList).
 
 


### PR DESCRIPTION
This is code we had before, ported to sync with the latest on master. We're now storing a 4-tuple in the by_id btree, it's been suggested by @davisp that we move to proplists/records.
