### PR TITLE
12833 conditional json encode

### DIFF
--- a/apps/couch/src/couch_rep.erl
+++ b/apps/couch/src/couch_rep.erl
@@ -834,7 +834,8 @@ ensure_full_commit(#http_db{headers = Headers} = Source, RequiredSeq) ->
     Req = Source#http_db{
         resource = "_ensure_full_commit",
         method = post,
-        qs = [{seq, iolist_to_binary(?JSON_ENCODE(RequiredSeq))}],
+        qs = [{seq, case RequiredSeq of Bin when is_binary(Bin) -> Bin;
+            Else -> iolist_to_binary(?JSON_ENCODE(Else)) end}],
         headers = Headers1
     },
     {ResultProps} = couch_rep_httpc:request(Req),

--- a/apps/couch/src/couch_rep_changes_feed.erl
+++ b/apps/couch/src/couch_rep_changes_feed.erl
@@ -64,7 +64,8 @@ init([Parent, #http_db{headers = Headers0} = Source, Since, PostProps]) ->
     BaseQS = [
         {"style", all_docs},
         {"heartbeat", 10000},
-        {"since", iolist_to_binary(?JSON_ENCODE(Since))},
+        {"since", case Since of Bin when is_binary(Bin) -> Bin;
+            Else -> iolist_to_binary(?JSON_ENCODE(Else)) end},
         {"feed", Feed}
     ],
     {QS, Method, Body, Headers} = case get_value(<<"doc_ids">>, PostProps) of


### PR DESCRIPTION
BigCouch 0.3 cannot parse requests of the form /db/_changes?since="123-foo" so
the recent ?JSON_ENCODE addition to Since in two places causes 0.3 <-> 0.4
replication to fail with json_encode/badterm errors.

This patch applies JSON encoding only when the Since value is not already a
binary (i.e, when it's a [integer(), binary()]) and interop is restored.

BugzID: 12833
