### PR TITLE
Added always to fix a fatal result

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ compile:
 	@echo "==> couchjs (compile)"
 	@cd couchjs && python scons/scons.py
 	@./rebar compile
-	@cat $(appfile) | sed s/%VSN%/`git describe --match 1.*`/ > $(appfile)
+	@cat $(appfile) | sed s/%VSN%/`git describe --match 1.* --always`/ > $(appfile)
 
 clean:
 	@echo "==> couchjs (clean)"

--- a/couchjs/c_src/SConscript
+++ b/couchjs/c_src/SConscript
@@ -105,7 +105,7 @@ if not env.GetOption('clean'):
 
     ## Define properties for -h / -V
 
-    (_, vsn) = runcmd("git describe --match 1.*")
+    (_, vsn) = runcmd("git describe --match 1.* --always")
     conf.Define("PACKAGE_STRING", '"%s"' % vsn.rstrip())
     conf.Define("PACKAGE_NAME", '"Cloudant BigCouch"')
     conf.Define("PACKAGE_BUGREPORT", '"https://github.com/cloudant/bigcouch/issues"')


### PR DESCRIPTION
The generated build/config.h errors when `git describe` returns something like fatal: No tags can describe '986c86bf4355ea2b772e141d008efd1894b7df30'.
Try --always, or create some tags.