### PR TITLE
Allow building on Gentoo

### DIFF
--- a/couchjs/c_src/SConscript
+++ b/couchjs/c_src/SConscript
@@ -70,9 +70,10 @@ if not env.GetOption('clean'):
     if not conf.CheckLibWithHeader('mozjs185-1.0', jsapi, 'c', autoadd=1):
         if not conf.CheckLibWithHeader('mozjs', jsapi, 'c', autoadd=1):
             if not conf.CheckLibWithHeader('js', jsapi, 'c', autoadd=1):
-                print 'Could not find JS library.', \
-                    'Is Mozilla SpiderMonkey installed?'
-                Exit(1)
+                if not conf.CheckLibWithHeader('mozjs185', jsapi, 'c', autoadd=1):
+                    print 'Could not find JS library.', \
+                        'Is Mozilla SpiderMonkey installed?'
+                    Exit(1)
 
     ## Detect the version of SpiderMonkey we're using
     jsheader = "#include <%s>" % jsapi


### PR DESCRIPTION
Gentoo uses a different name for the spidermonkey/mozjs lib. This one-line patch detects the lib correctly and makes bigcouch build on gentoo.
