### PR TITLE
Expose latest=true option in calls to retrieve revisions

### DIFF
--- a/apps/couch/src/couch_httpd_db.erl
+++ b/apps/couch/src/couch_httpd_db.erl
@@ -1216,6 +1216,9 @@ parse_doc_query(Req) ->
         {"open_revs", RevsJsonStr} ->
             JsonArray = ?JSON_DECODE(RevsJsonStr),
             Args#doc_query_args{open_revs=couch_doc:parse_revs(JsonArray)};
+        {"latest", "true"} ->
+            Options = [latest | Args#doc_query_args.options],
+            Args#doc_query_args{options=Options};
         {"atts_since", RevsJsonStr} ->
             JsonArray = ?JSON_DECODE(RevsJsonStr),
             Args#doc_query_args{atts_since = couch_doc:parse_revs(JsonArray)};


### PR DESCRIPTION
When a call is made to retrieve a specific revision, latest=true will
retrieve any descendent leaves instead. This enables the replicator to
better keep up with edits that occur whilst it's retrieving revisions

BugzID: 14241
