### PR TITLE
Use client certificates when replicating

### DIFF
--- a/apps/couch/src/couch_rep_httpc.erl
+++ b/apps/couch/src/couch_rep_httpc.erl
@@ -290,14 +290,23 @@ ssl_options(#http_db{url = Url}) ->
         Depth = list_to_integer(
             couch_config:get("replicator", "ssl_certificate_max_depth", "3")
         ),
-        SslOpts = [{depth, Depth} |
-        case couch_config:get("replicator", "verify_ssl_certificates") of
-        "true" ->
-            ssl_verify_options(true);
-        _ ->
-            ssl_verify_options(false)
-        end],
-        [{is_ssl, true}, {ssl_options, SslOpts}];
+        VerifyCerts = couch_config:get("replicator", "verify_ssl_certificates"),
+        CertFile = couch_config:get("replicator", "cert_file", nil),
+        KeyFile = couch_config:get("replicator", "key_file", nil),
+        Password = couch_config:get("replicator", "password", nil),
+        SslOpts = [{depth, Depth} | ssl_verify_options(VerifyCerts =:= "true")],
+        SslOpts1 = case CertFile /= nil andalso KeyFile /= nil of
+            true ->
+                case Password of
+                    nil ->
+                        [{certfile, CertFile}, {keyfile, KeyFile}] ++ SslOpts;
+                    _ ->
+                        [{certfile, CertFile}, {keyfile, KeyFile},
+                            {password, Password}] ++ SslOpts
+                end;
+            false -> SslOpts
+        end,
+        [{is_ssl, true}, {ssl_options, SslOpts1}];
     #url{protocol = http} ->
         []
     end.


### PR DESCRIPTION
This patch enables the bigcouch replicator to have the same functionality
as couchdb when replicating. When connecting to a remote couch over
SSL, the replicator will look for the cert_file, key_file params in the
replicator section of the config. If they exist, the replicator will
present the credentials to the other side
